### PR TITLE
Fix all errors and warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Vulkan REQUIRED)
 
 add_custom_command(
 	OUTPUT "${CMAKE_BINARY_DIR}/Square.spv"
-	COMMAND $ENV{VK_SDK_PATH}/Bin/dxc -T cs_6_0 -E "Main" -spirv -fvk-use-dx-layout -fspv-target-env=vulkan1.1 -Fo "${CMAKE_BINARY_DIR}/Square.spv" "Square.hlsl"
+	COMMAND dxc -T cs_6_0 -E "Main" -spirv -fvk-use-dx-layout -fspv-target-env=vulkan1.1 -Fo "${CMAKE_BINARY_DIR}/Square.spv" "Square.hlsl"
 	DEPENDS "Square.hlsl"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	COMMENT "Buiding Shaders"

--- a/main.cpp
+++ b/main.cpp
@@ -68,6 +68,7 @@ int main()
 			1,											// Number of queue family indices
 			&ComputeQueueFamilyIndex					// List of queue family indices
 		};
+		auto vkBufferCreateInfo = static_cast<VkBufferCreateInfo>(BufferCreateInfo);
 
 #ifdef WITH_VMA
 		VmaAllocatorCreateInfo AllocatorInfo = {};
@@ -87,7 +88,7 @@ int main()
 
 		VmaAllocation InBufferAllocation;
 		vmaCreateBuffer(Allocator,
-						&static_cast<VkBufferCreateInfo>(BufferCreateInfo),
+						&vkBufferCreateInfo,
 						&AllocationInfo,
 						&InBufferRaw,
 						&InBufferAllocation,
@@ -96,7 +97,7 @@ int main()
 		AllocationInfo.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
 		VmaAllocation OutBufferAllocation;
 		vmaCreateBuffer(Allocator,
-						&static_cast<VkBufferCreateInfo>(BufferCreateInfo),
+						&vkBufferCreateInfo,
 						&AllocationInfo,
 						&OutBufferRaw,
 						&OutBufferAllocation,
@@ -187,7 +188,7 @@ int main()
 		vk::ComputePipelineCreateInfo ComputePipelineCreateInfo(vk::PipelineCreateFlags(),	// Flags
 																PipelineShaderCreateInfo,	// Shader Create Info struct
 																PipelineLayout);			// Pipeline Layout
-		vk::Pipeline ComputePipeline = Device.createComputePipeline(PipelineCache, ComputePipelineCreateInfo);
+		vk::Pipeline ComputePipeline = Device.createComputePipeline(PipelineCache, ComputePipelineCreateInfo).value;
 
 		vk::DescriptorPoolSize DescriptorPoolSize(vk::DescriptorType::eStorageBuffer, 2);
 		vk::DescriptorPoolCreateInfo DescriptorPoolCreateInfo(vk::DescriptorPoolCreateFlags(), 1, DescriptorPoolSize);
@@ -234,7 +235,7 @@ int main()
 								  1,			// Num Command Buffers
 								  &CmdBuffer);  // List of command buffers
 		Queue.submit({ SubmitInfo }, Fence);
-		Device.waitForFences({ Fence },			// List of fences
+		auto result = Device.waitForFences({ Fence },			// List of fences
 							 true,				// Wait All
 							 uint64_t(-1));		// Timeout
 
@@ -274,12 +275,14 @@ int main()
 				&ComputeQueueFamilyIndex					// List of queue family indices
 			};
 
+			auto vkBufferCreateInfo = static_cast<VkBufferCreateInfo>(BufferCreateInfo);
+
 			VmaAllocationCreateInfo AllocationInfo = {};
 			AllocationInfo.usage = Usage;
 
 			BufferInfo Info;
 			vmaCreateBuffer(Allocator,
-							&static_cast<VkBufferCreateInfo>(BufferCreateInfo),
+							&vkBufferCreateInfo,
 							&AllocationInfo,
 							&Info.Buffer,
 							&Info.Allocation,

--- a/vk_mem_alloc.h
+++ b/vk_mem_alloc.h
@@ -16287,7 +16287,7 @@ VMA_CALL_PRE VkResult VMA_CALL_POST vmaCreateAllocator(
 {
     VMA_ASSERT(pCreateInfo && pAllocator);
     VMA_ASSERT(pCreateInfo->vulkanApiVersion == 0 ||
-        (VK_VERSION_MAJOR(pCreateInfo->vulkanApiVersion) == 1 && VK_VERSION_MINOR(pCreateInfo->vulkanApiVersion) <= 2));
+        (VK_VERSION_MAJOR(pCreateInfo->vulkanApiVersion) == 1 && VK_VERSION_MINOR(pCreateInfo->vulkanApiVersion) <= 3));
     VMA_DEBUG_LOG("vmaCreateAllocator");
     *pAllocator = vma_new(pCreateInfo->pAllocationCallbacks, VmaAllocator_T)(pCreateInfo);
     return (*pAllocator)->Init(pCreateInfo);


### PR DESCRIPTION
# Compile time errors  with g++ 13.2:

## Error fixed:
> VulkanHpp-Compute-Sample/main.cpp:90:50: error: taking address of rvalue [-fpermissive]
>    90 |                                                 &static_cast<VkBufferCreateInfo>(BufferCreateInfo),

## Warning fixed:

> VulkanHpp-Compute-Sample/main.cpp:237:37: warning: ignoring return value of ‘vk::Result vk::Device::waitForFences(const vk::ArrayProxy<const vk::Fence>&, vk::Bool32, uint64_t, const Dispatch&) const [with Dispatch = vk::DispatchLoaderStatic; vk::Bool32 = unsigned int; uint64_t = long unsigned int]’, declared with attribute ‘nodiscard’ [-Wunused-result]

## Error fixed:

> VulkanHpp-Compute-Sample/main.cpp:192:76: error: conversion from ‘vk::ResultValue<vk::Pipeline>’ to non-scalar type ‘vk::Pipeline’ requested
>   192 |                 vk::Pipeline ComputePipeline = Device.createComputePipeline(PipelineCache, ComputePipelineCreateInfo);

# Runtime errors:

## Fixed:
VulkanCompute: VulkanHpp-Compute-Sample/vk_mem_alloc.h:16289: VkResult vmaCreateAllocator(const VmaAllocatorCreateInfo*, VmaAllocator_T**): Assertion `pCreateInfo->vulkanApiVersion == 0 || (((uint32_t)(pCreateInfo->vulkanApiVersion) >> 22U) == 1 && (((uint32_t)(pCreateInfo->vulkanApiVersion) >> 12U) & 0x3FFU) <= 2)' failed.
